### PR TITLE
Update ec2.tf

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -15,7 +15,7 @@ provider "aws" {
 }
 
 resource "aws_instance" "app_server" {
-  ami           = "ami-830c94e3"
+  ami           = "ami-0d70546e43a941d70"
   instance_type = "t2.micro"
 
   tags = {


### PR DESCRIPTION
updated the AMI  if you all wanna change it to the newer AMI that is using ubuntu 22.04. The other AMI was using ubuntu 12.04 which is EOF as of 2017 and doesn't work with new apt commands 